### PR TITLE
Fix textarea's height is not 100% in Firefox

### DIFF
--- a/SimpleTimeTracker.elm
+++ b/SimpleTimeTracker.elm
@@ -139,6 +139,7 @@ make_input address text =
 container_style =
   style
     [ ("display", "flex")
+    , ("height","100vh")
     ]
 
 item_style : Attribute
@@ -147,6 +148,7 @@ item_style =
     [ ("flex-grow", "1")
     , ("flex-shrink", "1")
     , ("flex-basis", "150px")
+    , ("height","100%")
     ]
 
 textarea_style : Attribute


### PR DESCRIPTION
Tested with Firefox 44.0.2. Elm Platform 0.16.0.
